### PR TITLE
Modified Test Model to use own input constants for modul interfaces

### DIFF
--- a/VnVUserStories/VnVUserStoryTUBS/05-Work/CheckBGInt/CheckBGInputChannel_Pkg.xscade
+++ b/VnVUserStories/VnVUserStoryTUBS/05-Work/CheckBGInt/CheckBGInputChannel_Pkg.xscade
@@ -83990,6 +83990,8054 @@
 						<ed:Constant oid="!ed/ac648/17C9/9D4/5578405e177c"/>
 					</pragmas>
 				</Constant>
+				<Constant name="cNoFilterEvents">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="Common_Types_Pkg::filterRelatedEvents_T"/>
+							</type>
+						</NamedType>
+					</type>
+					<value>
+						<!-- {pendingL1Transition : false, pendingL12L3Transition : false, pendingAckOfTrainDa... -->
+						<DataStructOp>
+							<data>
+								<LabelledExpression label="pendingL1Transition">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="pendingL12L3Transition">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="pendingAckOfTrainDataFromRBC">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="emergencyStopAccepted">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="lastAckTextMessageId">
+									<flow>
+										<ConstValue value="0"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="pendingNTCTransition">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="SPPAndGradientOnBoard">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="MACoverNotFullLength">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+							</data>
+						</DataStructOp>
+					</value>
+					<pragmas>
+						<ed:Constant oid="!ed/291610/7D5B/1C58/559d3f9d955"/>
+					</pragmas>
+				</Constant>
+				<Constant name="cTNVContact">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="Obu_BasicTypes_Pkg::T_internal_Type"/>
+							</type>
+						</NamedType>
+					</type>
+					<value>
+						<ConstValue value="30000"/>
+					</value>
+					<pragmas>
+						<ed:Constant oid="!ed/2920f6/7D5B/1C58/559d3fc53ee2"/>
+					</pragmas>
+				</Constant>
+				<Constant name="cQNVLocAcc">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="Q_NVLOCACC"/>
+							</type>
+						</NamedType>
+					</type>
+					<value>
+						<ConstValue value="12"/>
+					</value>
+					<pragmas>
+						<ed:Constant oid="!ed/2920e7/7D5B/1C58/559d3fc54b5"/>
+					</pragmas>
+				</Constant>
+				<Constant name="cModeAndLevelStatus">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="Level_And_Mode_Types_Pkg::T_Mode_Level"/>
+							</type>
+						</NamedType>
+					</type>
+					<value>
+						<!-- {valid : true, level : M_LEVEL_Level_1, Mode : M_MODE_Full_Supervision} -->
+						<DataStructOp>
+							<data>
+								<LabelledExpression label="valid">
+									<flow>
+										<ConstValue value="true"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="level">
+									<flow>
+										<IdExpression>
+											<path>
+												<ConstVarRef name="M_LEVEL_Level_1"/>
+											</path>
+										</IdExpression>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="Mode">
+									<flow>
+										<IdExpression>
+											<path>
+												<ConstVarRef name="M_MODE_Full_Supervision"/>
+											</path>
+										</IdExpression>
+									</flow>
+								</LabelledExpression>
+							</data>
+						</DataStructOp>
+					</value>
+					<pragmas>
+						<ed:Constant oid="!ed/291fb2/7D5B/1C58/559d3fc5e22"/>
+					</pragmas>
+				</Constant>
+				<Constant name="cNoPositionedBGs">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="TrainPosition_Types_Pck::positionedBGs_T"/>
+							</type>
+						</NamedType>
+					</type>
+					<value>
+						<!-- [{valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nom... -->
+						<DataArrayOp>
+							<data>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+								<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+								<DataStructOp>
+									<data>
+										<LabelledExpression label="valid">
+											<flow>
+												<ConstValue value="false"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_c">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="nid_bg">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="q_link">
+											<flow>
+												<IdExpression>
+													<path>
+														<ConstVarRef name="Q_LINK_Unlinked"/>
+													</path>
+												</IdExpression>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="location">
+											<flow>
+												<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="nominal">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_min">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_max">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="seqNoOnTrack">
+											<flow>
+												<ConstValue value="0"/>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromLinking">
+											<flow>
+												<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_bg_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="nid_c_fromLinkingBG">
+															<flow>
+																<ConstValue value="0"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="expectedLocation">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="d_link">
+															<flow>
+																<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="nominal">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_min">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_max">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkingInfo">
+															<flow>
+																<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_LRBG">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_dir">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIR_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_scale">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="d_link">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_newcountry">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkorientation">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_linkreaction">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_locacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+										<LabelledExpression label="infoFromPassing">
+											<flow>
+												<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+												<DataStructOp>
+													<data>
+														<LabelledExpression label="valid">
+															<flow>
+																<ConstValue value="false"/>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="BG_Header">
+															<flow>
+																<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																<DataStructOp>
+																	<data>
+																		<LabelledExpression label="valid">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_updown">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_version">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_media">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_MEDIA_Balise"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="n_total">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="m_mcount">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_c">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="nid_bg">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_link">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_LINK_Unlinked"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="bgPosition">
+																			<flow>
+																				<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="timestamp">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="odo">
+																							<flow>
+																								<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="o_nominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_min">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="o_max">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="speed">
+																							<flow>
+																								<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																								<DataStructOp>
+																									<data>
+																										<LabelledExpression label="v_safeNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_rawNominal">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_lower">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																										<LabelledExpression label="v_upper">
+																											<flow>
+																												<ConstValue value="0"/>
+																											</flow>
+																										</LabelledExpression>
+																									</data>
+																								</DataStructOp>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="acceleration">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionState">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="motionDirection">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																			<flow>
+																				<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="nominal">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_min">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_max">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="q_nvlocacc">
+																			<flow>
+																				<ConstValue value="0"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																			<flow>
+																				<ConstValue value="false"/>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainOrientationToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																		<LabelledExpression label="trainRunningDirectionToBG">
+																			<flow>
+																				<IdExpression>
+																					<path>
+																						<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																					</path>
+																				</IdExpression>
+																			</flow>
+																		</LabelledExpression>
+																	</data>
+																</DataStructOp>
+															</flow>
+														</LabelledExpression>
+														<LabelledExpression label="linkedBGs">
+															<flow>
+																<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																<DataArrayOp>
+																	<data>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</data>
+																</DataArrayOp>
+															</flow>
+														</LabelledExpression>
+													</data>
+												</DataStructOp>
+											</flow>
+										</LabelledExpression>
+									</data>
+								</DataStructOp>
+							</data>
+						</DataArrayOp>
+					</value>
+					<pragmas>
+						<ed:Constant oid="!ed/29320e/7D5B/1C58/559d404511d3"/>
+					</pragmas>
+				</Constant>
+				<Constant name="cTrainPosition_0">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="TrainPosition_Types_Pck::trainPosition_T"/>
+							</type>
+						</NamedType>
+					</type>
+					<value>
+						<!-- {valid : false, timestamp : 0, trainPositionIsUnknown : false, noCoordinateSystem... -->
+						<DataStructOp>
+							<data>
+								<LabelledExpression label="valid">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="timestamp">
+									<flow>
+										<ConstValue value="0"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="trainPositionIsUnknown">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="trainPosition">
+									<flow>
+										<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+										<DataStructOp>
+											<data>
+												<LabelledExpression label="nominal">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="d_min">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="d_max">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+											</data>
+										</DataStructOp>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="estimatedFrontEndPosition">
+									<flow>
+										<ConstValue value="0"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="minSafeFrontEndPosition">
+									<flow>
+										<ConstValue value="0"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="maxSafeFrontEndPostion">
+									<flow>
+										<ConstValue value="0"/>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="LRBG">
+									<flow>
+										<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+										<DataStructOp>
+											<data>
+												<LabelledExpression label="valid">
+													<flow>
+														<ConstValue value="false"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="nid_c">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="nid_bg">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="q_link">
+													<flow>
+														<IdExpression>
+															<path>
+																<ConstVarRef name="Q_LINK_Unlinked"/>
+															</path>
+														</IdExpression>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="location">
+													<flow>
+														<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+														<DataStructOp>
+															<data>
+																<LabelledExpression label="nominal">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="d_min">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="d_max">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+															</data>
+														</DataStructOp>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="seqNoOnTrack">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="infoFromLinking">
+													<flow>
+														<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+														<DataStructOp>
+															<data>
+																<LabelledExpression label="valid">
+																	<flow>
+																		<ConstValue value="false"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="nid_bg_fromLinkingBG">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="nid_c_fromLinkingBG">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="expectedLocation">
+																	<flow>
+																		<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="nominal">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_min">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_max">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="d_link">
+																	<flow>
+																		<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="nominal">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_min">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_max">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="linkingInfo">
+																	<flow>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+															</data>
+														</DataStructOp>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="infoFromPassing">
+													<flow>
+														<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+														<DataStructOp>
+															<data>
+																<LabelledExpression label="valid">
+																	<flow>
+																		<ConstValue value="false"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="BG_Header">
+																	<flow>
+																		<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_updown">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="m_version">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_media">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_MEDIA_Balise"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="n_total">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="m_mcount">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_link">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINK_Unlinked"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="bgPosition">
+																					<flow>
+																						<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																						<DataStructOp>
+																							<data>
+																								<LabelledExpression label="valid">
+																									<flow>
+																										<ConstValue value="false"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="timestamp">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="odo">
+																									<flow>
+																										<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																										<DataStructOp>
+																											<data>
+																												<LabelledExpression label="o_nominal">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="o_min">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="o_max">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																											</data>
+																										</DataStructOp>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="speed">
+																									<flow>
+																										<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																										<DataStructOp>
+																											<data>
+																												<LabelledExpression label="v_safeNominal">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="v_rawNominal">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="v_lower">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="v_upper">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																											</data>
+																										</DataStructOp>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="acceleration">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="motionState">
+																									<flow>
+																										<IdExpression>
+																											<path>
+																												<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																											</path>
+																										</IdExpression>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="motionDirection">
+																									<flow>
+																										<IdExpression>
+																											<path>
+																												<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																											</path>
+																										</IdExpression>
+																									</flow>
+																								</LabelledExpression>
+																							</data>
+																						</DataStructOp>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																					<flow>
+																						<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																						<DataStructOp>
+																							<data>
+																								<LabelledExpression label="nominal">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="d_min">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="d_max">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																							</data>
+																						</DataStructOp>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_nvlocacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="trainOrientationToBG">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="trainRunningDirectionToBG">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="linkedBGs">
+																	<flow>
+																		<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																		<DataArrayOp>
+																			<data>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</data>
+																		</DataArrayOp>
+																	</flow>
+																</LabelledExpression>
+															</data>
+														</DataStructOp>
+													</flow>
+												</LabelledExpression>
+											</data>
+										</DataStructOp>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="prvLRBG">
+									<flow>
+										<!-- {valid : false, nid_c : 0, nid_bg : 0, q_link : Q_LINK_Unlinked, location : {nomi... -->
+										<DataStructOp>
+											<data>
+												<LabelledExpression label="valid">
+													<flow>
+														<ConstValue value="false"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="nid_c">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="nid_bg">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="q_link">
+													<flow>
+														<IdExpression>
+															<path>
+																<ConstVarRef name="Q_LINK_Unlinked"/>
+															</path>
+														</IdExpression>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="location">
+													<flow>
+														<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+														<DataStructOp>
+															<data>
+																<LabelledExpression label="nominal">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="d_min">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="d_max">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+															</data>
+														</DataStructOp>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="seqNoOnTrack">
+													<flow>
+														<ConstValue value="0"/>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="infoFromLinking">
+													<flow>
+														<!-- {valid : false, nid_bg_fromLinkingBG : 0, nid_c_fromLinkingBG : 0, expectedLocati... -->
+														<DataStructOp>
+															<data>
+																<LabelledExpression label="valid">
+																	<flow>
+																		<ConstValue value="false"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="nid_bg_fromLinkingBG">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="nid_c_fromLinkingBG">
+																	<flow>
+																		<ConstValue value="0"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="expectedLocation">
+																	<flow>
+																		<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="nominal">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_min">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_max">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="d_link">
+																	<flow>
+																		<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="nominal">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_min">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_max">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="linkingInfo">
+																	<flow>
+																		<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_LRBG">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_dir">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIR_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_scale">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="d_link">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_newcountry">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkorientation">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_linkreaction">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_locacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+															</data>
+														</DataStructOp>
+													</flow>
+												</LabelledExpression>
+												<LabelledExpression label="infoFromPassing">
+													<flow>
+														<!-- {valid : false, BG_Header : {valid : false, q_updown : Q_UPDOWN_Down_link_telegra... -->
+														<DataStructOp>
+															<data>
+																<LabelledExpression label="valid">
+																	<flow>
+																		<ConstValue value="false"/>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="BG_Header">
+																	<flow>
+																		<!-- {valid : false, q_updown : Q_UPDOWN_Down_link_telegram, m_version : M_VERSION_Pre... -->
+																		<DataStructOp>
+																			<data>
+																				<LabelledExpression label="valid">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_updown">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_UPDOWN_Down_link_telegram"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="m_version">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="M_VERSION_Previous_versions_according_to_e_g_EEIG_SRS_and_UIC_A200_SRS"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_media">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_MEDIA_Balise"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="n_total">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="N_TOTAL_1_balise_in_the_group"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="m_mcount">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_c">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="nid_bg">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_link">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_LINK_Unlinked"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="bgPosition">
+																					<flow>
+																						<!-- {valid : false, timestamp : 0, odo : {o_nominal : 0, o_min : 0, o_max : 0}, speed... -->
+																						<DataStructOp>
+																							<data>
+																								<LabelledExpression label="valid">
+																									<flow>
+																										<ConstValue value="false"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="timestamp">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="odo">
+																									<flow>
+																										<!-- {o_nominal : 0, o_min : 0, o_max : 0} -->
+																										<DataStructOp>
+																											<data>
+																												<LabelledExpression label="o_nominal">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="o_min">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="o_max">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																											</data>
+																										</DataStructOp>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="speed">
+																									<flow>
+																										<!-- {v_safeNominal : 0, v_rawNominal : 0, v_lower : 0, v_upper : 0} -->
+																										<DataStructOp>
+																											<data>
+																												<LabelledExpression label="v_safeNominal">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="v_rawNominal">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="v_lower">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																												<LabelledExpression label="v_upper">
+																													<flow>
+																														<ConstValue value="0"/>
+																													</flow>
+																												</LabelledExpression>
+																											</data>
+																										</DataStructOp>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="acceleration">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="motionState">
+																									<flow>
+																										<IdExpression>
+																											<path>
+																												<ConstVarRef name="Obu_BasicTypes_Pkg::noMotion"/>
+																											</path>
+																										</IdExpression>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="motionDirection">
+																									<flow>
+																										<IdExpression>
+																											<path>
+																												<ConstVarRef name="Obu_BasicTypes_Pkg::unknownDirection"/>
+																											</path>
+																										</IdExpression>
+																									</flow>
+																								</LabelledExpression>
+																							</data>
+																						</DataStructOp>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="BG_centerDetectionInaccuraccuracies">
+																					<flow>
+																						<!-- {nominal : 0, d_min : 0, d_max : 0} -->
+																						<DataStructOp>
+																							<data>
+																								<LabelledExpression label="nominal">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="d_min">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																								<LabelledExpression label="d_max">
+																									<flow>
+																										<ConstValue value="0"/>
+																									</flow>
+																								</LabelledExpression>
+																							</data>
+																						</DataStructOp>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="q_nvlocacc">
+																					<flow>
+																						<ConstValue value="0"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="noCoordinateSystemHasBeenAssigned">
+																					<flow>
+																						<ConstValue value="false"/>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="trainOrientationToBG">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																				<LabelledExpression label="trainRunningDirectionToBG">
+																					<flow>
+																						<IdExpression>
+																							<path>
+																								<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+																							</path>
+																						</IdExpression>
+																					</flow>
+																				</LabelledExpression>
+																			</data>
+																		</DataStructOp>
+																	</flow>
+																</LabelledExpression>
+																<LabelledExpression label="linkedBGs">
+																	<flow>
+																		<!-- [{valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_sca... -->
+																		<DataArrayOp>
+																			<data>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																				<!-- {valid : false, nid_LRBG : 0, q_dir : Q_DIR_Reverse, q_scale : Q_SCALE_10_cm_scal... -->
+																				<DataStructOp>
+																					<data>
+																						<LabelledExpression label="valid">
+																							<flow>
+																								<ConstValue value="false"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_LRBG">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_dir">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_DIR_Reverse"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_scale">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_SCALE_10_cm_scale"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="d_link">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_newcountry">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_NEWCOUNTRY_Same_country__or__railway_administration_no_NID_C_follows"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_c">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="nid_bg">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkorientation">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKORIENTATION_The_balise_group_is_seen_by_the_train_in_reverse_direction"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_linkreaction">
+																							<flow>
+																								<IdExpression>
+																									<path>
+																										<ConstVarRef name="Q_LINKREACTION_Train_trip"/>
+																									</path>
+																								</IdExpression>
+																							</flow>
+																						</LabelledExpression>
+																						<LabelledExpression label="q_locacc">
+																							<flow>
+																								<ConstValue value="0"/>
+																							</flow>
+																						</LabelledExpression>
+																					</data>
+																				</DataStructOp>
+																			</data>
+																		</DataArrayOp>
+																	</flow>
+																</LabelledExpression>
+															</data>
+														</DataStructOp>
+													</flow>
+												</LabelledExpression>
+											</data>
+										</DataStructOp>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="nominalOrReverseToLRBG">
+									<flow>
+										<IdExpression>
+											<path>
+												<ConstVarRef name="Q_DLRBG_Reverse"/>
+											</path>
+										</IdExpression>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="trainOrientationToLRBG">
+									<flow>
+										<IdExpression>
+											<path>
+												<ConstVarRef name="Q_DIRLRBG_Reverse"/>
+											</path>
+										</IdExpression>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="trainRunningDirectionToLRBG">
+									<flow>
+										<IdExpression>
+											<path>
+												<ConstVarRef name="Q_DIRTRAIN_Reverse"/>
+											</path>
+										</IdExpression>
+									</flow>
+								</LabelledExpression>
+								<LabelledExpression label="linkingIsUsedOnboard">
+									<flow>
+										<ConstValue value="false"/>
+									</flow>
+								</LabelledExpression>
+							</data>
+						</DataStructOp>
+					</value>
+					<pragmas>
+						<ed:Constant oid="!ed/293693/7D5B/1C58/559d40602481"/>
+					</pragmas>
+				</Constant>
 				<Type name="delaytime_T">
 					<definition>
 						<NamedType>

--- a/VnVUserStories/VnVUserStoryTUBS/05-Work/CheckBGInt/NightlyVerificationSetup.csv
+++ b/VnVUserStories/VnVUserStoryTUBS/05-Work/CheckBGInt/NightlyVerificationSetup.csv
@@ -1,7 +1,7 @@
 sep=,
 validation\VnVUserStories\VnVUserStoryTUBS\05-Work\CheckBGInt\CheckBGInputChannel.etp,
 Manage_TrackSideInformation_Integration_Pkg::Manage_TrackSideInformation_Integration/,
-d47c50cae56d70f9e0ee11e986636539ba338dcc,
+da86a5f379f391a80e01d1b2f81d2f736876426b,
 CheckBGInputChannel_Pkg::ROOT_CheckBGInCh_Int/,
 SimuVV.sss,
 observables_checkedBGs.obs,

--- a/VnVUserStories/VnVUserStoryTUBS/05-Work/CheckBGInt/Root_CheckBGInCh_Int.xscade
+++ b/VnVUserStories/VnVUserStoryTUBS/05-Work/CheckBGInt/Root_CheckBGInCh_Int.xscade
@@ -1317,7 +1317,7 @@
 				<ed:Equation oid="!ed/bdb8f/5732/1598/557aef235a31"/>
 			</pragmas>
 		</Equation>
-		<!-- _L98 = CalculateTrainPosition_Pkg::cNoPositionedBGs; -->
+		<!-- _L98 = cNoPositionedBGs; -->
 		<Equation>
 			<lefts>
 				<VariableRef name="_L98"/>
@@ -1325,7 +1325,7 @@
 			<right>
 				<IdExpression>
 					<path>
-						<ConstVarRef name="CalculateTrainPosition_Pkg::cNoPositionedBGs"/>
+						<ConstVarRef name="cNoPositionedBGs"/>
 					</path>
 				</IdExpression>
 			</right>
@@ -1498,7 +1498,7 @@
 				<ed:Equation oid="!ed/c44e7/E46/1C0C/557b12d65499"/>
 			</pragmas>
 		</Equation>
-		<!-- _L126 = CalculateTrainPosition_Pkg::cTrainPosition_0; -->
+		<!-- _L126 = cTrainPosition_0; -->
 		<Equation>
 			<lefts>
 				<VariableRef name="_L126"/>
@@ -1506,7 +1506,7 @@
 			<right>
 				<IdExpression>
 					<path>
-						<ConstVarRef name="CalculateTrainPosition_Pkg::cTrainPosition_0"/>
+						<ConstVarRef name="cTrainPosition_0"/>
 					</path>
 				</IdExpression>
 			</right>
@@ -1514,7 +1514,7 @@
 				<ed:Equation oid="!ed/c44e9/E46/1C0C/557b15706f62"/>
 			</pragmas>
 		</Equation>
-		<!-- _L128 = TestExample_Pkg::cModeAndLevelStatus; -->
+		<!-- _L128 = cModeAndLevelStatus; -->
 		<Equation>
 			<lefts>
 				<VariableRef name="_L128"/>
@@ -1522,7 +1522,7 @@
 			<right>
 				<IdExpression>
 					<path>
-						<ConstVarRef name="TestExample_Pkg::cModeAndLevelStatus"/>
+						<ConstVarRef name="cModeAndLevelStatus"/>
 					</path>
 				</IdExpression>
 			</right>
@@ -1530,7 +1530,7 @@
 				<ed:Equation oid="!ed/c45a1/E46/1C0C/557b163e2622"/>
 			</pragmas>
 		</Equation>
-		<!-- _L129 = TestExample_Pkg::cQNVLocAcc; -->
+		<!-- _L129 = cQNVLocAcc; -->
 		<Equation>
 			<lefts>
 				<VariableRef name="_L129"/>
@@ -1538,7 +1538,7 @@
 			<right>
 				<IdExpression>
 					<path>
-						<ConstVarRef name="TestExample_Pkg::cQNVLocAcc"/>
+						<ConstVarRef name="cQNVLocAcc"/>
 					</path>
 				</IdExpression>
 			</right>
@@ -1546,7 +1546,7 @@
 				<ed:Equation oid="!ed/c45a7/E46/1C0C/557b16497f0d"/>
 			</pragmas>
 		</Equation>
-		<!-- _L130 = TestExample_Pkg::cTNVContact; -->
+		<!-- _L130 = cTNVContact; -->
 		<Equation>
 			<lefts>
 				<VariableRef name="_L130"/>
@@ -1554,7 +1554,7 @@
 			<right>
 				<IdExpression>
 					<path>
-						<ConstVarRef name="TestExample_Pkg::cTNVContact"/>
+						<ConstVarRef name="cTNVContact"/>
 					</path>
 				</IdExpression>
 			</right>
@@ -2137,7 +2137,7 @@
 				<ed:Equation oid="!ed/253135/47E7/1D80/55940a4e1227"/>
 			</pragmas>
 		</Equation>
-		<!-- _L232 = Common_Types_Pkg::cNoFilterEvents; -->
+		<!-- _L232 = cNoFilterEvents; -->
 		<Equation>
 			<lefts>
 				<VariableRef name="_L232"/>
@@ -2145,7 +2145,7 @@
 			<right>
 				<IdExpression>
 					<path>
-						<ConstVarRef name="Common_Types_Pkg::cNoFilterEvents"/>
+						<ConstVarRef name="cNoFilterEvents"/>
 					</path>
 				</IdExpression>
 			</right>
@@ -2997,6 +2997,94 @@
 								<Point x="33390" y="23601"/>
 							</positions>
 						</Edge>
+						<EquationGE kind="OBJ_LIT" presentable="!ed/290bad/71C9/1298/559a8f39cb4">
+							<position>
+								<Point x="23310" y="15425"/>
+							</position>
+							<size>
+								<Size width="212" height="318"/>
+							</size>
+						</EquationGE>
+						<Edge leftVarIndex="7" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/1253df/2CF2/189C/5592aed21b20">
+							<positions>
+								<Point x="33232" y="14446"/>
+								<Point x="33761" y="14446"/>
+								<Point x="33761" y="14552"/>
+								<Point x="34316" y="14552"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="6" rightExprIndex="5" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
+							<positions>
+								<Point x="33232" y="12726"/>
+								<Point x="34581" y="12726"/>
+								<Point x="34581" y="20320"/>
+								<Point x="35957" y="20320"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="5" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdaa0/5732/1598/557aeab12cc6">
+							<positions>
+								<Point x="33232" y="11007"/>
+								<Point x="33787" y="11007"/>
+								<Point x="33787" y="11853"/>
+								<Point x="34369" y="11853"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="4" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdab7/5732/1598/557aeab16a1d">
+							<positions>
+								<Point x="33232" y="9287"/>
+								<Point x="33787" y="9287"/>
+								<Point x="33787" y="9948"/>
+								<Point x="34369" y="9948"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="3" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bda8c/5732/1598/557aeab15de">
+							<positions>
+								<Point x="33232" y="7541"/>
+								<Point x="33787" y="7541"/>
+								<Point x="33787" y="8043"/>
+								<Point x="34369" y="8043"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="3" rightExprIndex="3" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
+							<positions>
+								<Point x="33232" y="7541"/>
+								<Point x="34581" y="7541"/>
+								<Point x="34581" y="18971"/>
+								<Point x="35957" y="18971"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="2" rightExprIndex="4" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
+							<positions>
+								<Point x="33232" y="5821"/>
+								<Point x="34581" y="5821"/>
+								<Point x="34581" y="19632"/>
+								<Point x="35957" y="19632"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="2" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdaa5/5732/1598/557aeab11163">
+							<positions>
+								<Point x="33232" y="5821"/>
+								<Point x="33787" y="5821"/>
+								<Point x="33787" y="6165"/>
+								<Point x="34369" y="6165"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="1" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
+							<positions>
+								<Point x="33232" y="4101"/>
+								<Point x="34581" y="4101"/>
+								<Point x="34581" y="17595"/>
+								<Point x="35957" y="17595"/>
+							</positions>
+						</Edge>
+						<Edge leftVarIndex="1" rightExprIndex="16" srcEquation="!ed/290bad/71C9/1298/559a8f39cb4" dstEquation="!ed/bda72/5732/1598/557aeab17e1a">
+							<positions>
+								<Point x="23521" y="15584"/>
+								<Point x="24659" y="15584"/>
+								<Point x="24659" y="15346"/>
+								<Point x="25823" y="15346"/>
+							</positions>
+						</Edge>
 						<Edge leftVarIndex="1" rightExprIndex="15" srcEquation="!ed/bda79/5732/1598/557aeab15200" dstEquation="!ed/bda72/5732/1598/557aeab17e1a">
 							<positions>
 								<Point x="23839" y="13732"/>
@@ -3115,94 +3203,6 @@
 								<Point x="25188" y="3201"/>
 								<Point x="25188" y="3201"/>
 								<Point x="25823" y="3201"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="1" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
-							<positions>
-								<Point x="33232" y="4101"/>
-								<Point x="34581" y="4101"/>
-								<Point x="34581" y="17595"/>
-								<Point x="35957" y="17595"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="2" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdaa5/5732/1598/557aeab11163">
-							<positions>
-								<Point x="33232" y="5821"/>
-								<Point x="33787" y="5821"/>
-								<Point x="33787" y="6165"/>
-								<Point x="34369" y="6165"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="2" rightExprIndex="4" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
-							<positions>
-								<Point x="33232" y="5821"/>
-								<Point x="34581" y="5821"/>
-								<Point x="34581" y="19632"/>
-								<Point x="35957" y="19632"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="3" rightExprIndex="3" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
-							<positions>
-								<Point x="33232" y="7541"/>
-								<Point x="34581" y="7541"/>
-								<Point x="34581" y="18971"/>
-								<Point x="35957" y="18971"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="6" rightExprIndex="5" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdb87/5732/1598/557aeed77728">
-							<positions>
-								<Point x="33232" y="12726"/>
-								<Point x="34581" y="12726"/>
-								<Point x="34581" y="20320"/>
-								<Point x="35957" y="20320"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="7" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/1253df/2CF2/189C/5592aed21b20">
-							<positions>
-								<Point x="33232" y="14446"/>
-								<Point x="33761" y="14446"/>
-								<Point x="33761" y="14552"/>
-								<Point x="34316" y="14552"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="5" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdaa0/5732/1598/557aeab12cc6">
-							<positions>
-								<Point x="33232" y="11007"/>
-								<Point x="33787" y="11007"/>
-								<Point x="33787" y="11853"/>
-								<Point x="34369" y="11853"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="4" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bdab7/5732/1598/557aeab16a1d">
-							<positions>
-								<Point x="33232" y="9287"/>
-								<Point x="33787" y="9287"/>
-								<Point x="33787" y="9948"/>
-								<Point x="34369" y="9948"/>
-							</positions>
-						</Edge>
-						<Edge leftVarIndex="3" rightExprIndex="1" srcEquation="!ed/bda72/5732/1598/557aeab17e1a" dstEquation="!ed/bda8c/5732/1598/557aeab15de">
-							<positions>
-								<Point x="33232" y="7541"/>
-								<Point x="33787" y="7541"/>
-								<Point x="33787" y="8043"/>
-								<Point x="34369" y="8043"/>
-							</positions>
-						</Edge>
-						<EquationGE kind="OBJ_LIT" presentable="!ed/290bad/71C9/1298/559a8f39cb4">
-							<position>
-								<Point x="23310" y="15425"/>
-							</position>
-							<size>
-								<Size width="212" height="318"/>
-							</size>
-						</EquationGE>
-						<Edge leftVarIndex="1" rightExprIndex="16" srcEquation="!ed/290bad/71C9/1298/559a8f39cb4" dstEquation="!ed/bda72/5732/1598/557aeab17e1a">
-							<positions>
-								<Point x="23521" y="15584"/>
-								<Point x="24659" y="15584"/>
-								<Point x="24659" y="15346"/>
-								<Point x="25823" y="15346"/>
 							</positions>
 						</Edge>
 					</presentationElements>


### PR DESCRIPTION
I've made all input constants (which are used to provide input for the modul, whcih usually is provided by other moduls) to own constants of the test model. Before these constants have been taken from the modeling definitions for these moduls.